### PR TITLE
Display image in the correct orientation

### DIFF
--- a/main.py
+++ b/main.py
@@ -75,7 +75,7 @@ class Plot(wx.Panel):
 
         axF = self.figure.add_subplot(221)
         axF.set_title("distibution function")
-        im = axF.imshow(f.sum(axis=0), cmap="plasma", extent=[0, xmax, -vmax, vmax])
+        im = axF.imshow(f.sum(axis=0), cmap="plasma", extent=[0, xmax, -vmax, vmax], origin="lower")
         self.figure.colorbar(im)
 
         axR = self.figure.add_subplot(222)

--- a/main.py
+++ b/main.py
@@ -75,7 +75,8 @@ class Plot(wx.Panel):
 
         axF = self.figure.add_subplot(221)
         axF.set_title("distibution function")
-        im = axF.imshow(f.sum(axis=0), cmap="plasma", extent=[0, xmax, -vmax, vmax], origin="lower")
+        extent = [0, xmax, -vmax, vmax]
+        im = axF.imshow(f.sum(axis=0), cmap="plasma", extent=extent, origin="lower")
         self.figure.colorbar(im)
 
         axR = self.figure.add_subplot(222)


### PR DESCRIPTION
Use `origin="lower"` (https://matplotlib.org/stable/tutorials/intermediate/imshow_extent.html).

[![Image from Gyazo](https://i.gyazo.com/3eb77997b7851c1713ee2edcd90ea46d.png)](https://gyazo.com/3eb77997b7851c1713ee2edcd90ea46d)